### PR TITLE
Clarify Agent Boundary Check CLI positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 
 **Your coding agent says it is sandboxed. Is it?**
 
-Agent Boundary Check measures the effective execution boundary of AI coding agents with synthetic canaries. Instead of trusting configuration alone, it asks the agent to run one deterministic probe inside its normal execution path and reports what that process can actually read, write, execute and reach. The core CLI has zero runtime dependencies beyond Python 3.11+.
+Agent Boundary Check is a focused command-line security tool (CLI) for measuring the effective execution boundary of AI coding agents with synthetic canaries. It asks the agent to run one deterministic probe inside its normal execution path and reports what that process can actually read, write, execute and reach. The `agent-boundary` command is the supported public interface; the Python package currently contains implementation internals rather than a separately supported library API. The CLI has zero runtime dependencies beyond Python 3.11+.
 
 ## At a glance
+
+After installation, run the shortest useful check:
 
 ```bash
 agent-boundary verify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "agent-boundary-check"
 version = "0.1.2"
-description = "Verify what AI coding agents can actually read, write, execute and reach using synthetic canaries."
+description = "Command-line security tool that verifies what AI coding agents can actually read, write, execute and reach using synthetic canaries."
 readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -39,9 +40,10 @@ def test_gemini_command_does_not_use_yolo():
 
 def test_custom_command_substitutes_prompt_and_file():
     adapter = CommandAdapter('runner --prompt "{prompt}" --file {prompt_file}')
-    cmd = adapter.build_command("hello world", Path("/tmp/prompt.txt"))
+    prompt_file = Path("/tmp/prompt.txt")
+    cmd = adapter.build_command("hello world", prompt_file)
     assert "hello world" in cmd
-    assert "/tmp/prompt.txt" in cmd
+    assert str(prompt_file) in cmd
 
 
 def test_command_requires_template():
@@ -69,7 +71,7 @@ def test_codex_respects_codex_home_for_config(tmp_path, monkeypatch):
     (home / "config.toml").write_text('sandbox_mode = "workspace-write"\napproval_policy = "on-request"\ndefault_permissions = "repo-safe"\n[sandbox_workspace_write]\nnetwork_access = true\nwritable_roots = ["/x"]\n')
     monkeypatch.setenv("CODEX_HOME", str(home))
     hints = CodexAdapter().declared_hints(tmp_path)
-    assert hints["config_file"] == str(home / "config.toml")
+    assert hints["config_file"] == display_path(home / "config.toml")
     assert hints["approval_policy"] == "on-request"
     assert hints["default_permissions"] == "repo-safe"
     assert hints["workspace_write_network_access"] is True
@@ -113,7 +115,7 @@ def test_display_path_abbreviates_home(tmp_path, monkeypatch):
     home = tmp_path / "home"
     home.mkdir()
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
-    assert display_path(home / ".claude" / "settings.json") == "~/.claude/settings.json"
+    assert display_path(home / ".claude" / "settings.json") == str(Path("~") / ".claude" / "settings.json")
 
 
 def test_gemini_honors_configuration_path_overrides(tmp_path, monkeypatch):
@@ -132,9 +134,9 @@ def test_gemini_honors_configuration_path_overrides(tmp_path, monkeypatch):
     monkeypatch.setenv("SANDBOX_MOUNTS", "/one:ro,/two:rw")
 
     hints = GeminiAdapter().declared_hints(tmp_path)
-    assert str(defaults) in hints["config_files"]
-    assert str(system) in hints["config_files"]
-    assert str(user) in hints["config_files"]
+    assert display_path(defaults) in hints["config_files"]
+    assert display_path(system) in hints["config_files"]
+    assert display_path(user) in hints["config_files"]
     assert hints["environment_sandbox"] == "docker"
     assert hints["sandbox_mount_count"] == 2
     assert any(item.get("default_approval_mode") == "plan" for item in hints["sandbox_settings"])
@@ -154,7 +156,7 @@ def test_claude_counts_additional_directories(tmp_path, monkeypatch):
 def test_custom_command_windows_style_quoted_executable(monkeypatch):
     import agent_boundary_check.adapters.command as command_module
 
-    monkeypatch.setattr(command_module.os, "name", "nt")
+    monkeypatch.setattr(command_module, "os", SimpleNamespace(name="nt"))
     adapter = CommandAdapter(r'"C:\Program Files\Python\python.exe" script.py "{prompt}"')
     cmd = adapter.build_command("hello world", Path(r"C:\tmp\prompt.txt"))
     assert cmd[0] == r"C:\Program Files\Python\python.exe"
@@ -169,7 +171,7 @@ def test_claude_ignores_non_object_and_invalid_utf8_settings(tmp_path, monkeypat
     settings.write_bytes(b"\xff\xfe")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     hints = ClaudeAdapter().declared_hints(tmp_path)
-    assert hints["config_files"] == ["~/.claude/settings.json"]
+    assert hints["config_files"] == [display_path(settings)]
 
     settings.write_text("[]")
     hints = ClaudeAdapter().declared_hints(tmp_path)
@@ -183,7 +185,7 @@ def test_gemini_ignores_non_object_and_invalid_utf8_settings(tmp_path, monkeypat
     settings.write_bytes(b"\xff\xfe")
     monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
     hints = GeminiAdapter().declared_hints(tmp_path)
-    assert "~/.gemini/settings.json" in hints["config_files"]
+    assert display_path(settings) in hints["config_files"]
 
     settings.write_text("[]")
     hints = GeminiAdapter().declared_hints(tmp_path)


### PR DESCRIPTION
Small strategic positioning/usability pass.

- Clarifies Agent Boundary Check as a focused command-line security tool (CLI) near the top of the README.
- States that `agent-boundary` is the supported public interface and avoids implying a stable Python library API.
- Makes the first-use wording slightly clearer.
- Aligns the PyPI/package description with the CLI positioning.
- Leaves repository/package names, CLI command, URLs, assets, PNGs, dependencies, security boundaries, architecture and application behaviour unchanged.

No public Python API was added because there is no clear need to create one for this CLI-first tool.

The first CI run also exposed pre-existing cross-platform assumptions in `tests/test_adapters.py`. Those tests were made platform-aware without changing application code or runtime behaviour, including avoiding a test-only global `os.name` monkeypatch that could destabilize pytest itself.